### PR TITLE
Change BCU mask version from 2705 to 27B0

### DIFF
--- a/MainWindowViewModel.cs
+++ b/MainWindowViewModel.cs
@@ -212,7 +212,7 @@ namespace CreateKnxProd
             }
             else if (_hardware2Program.MediumTypes[0] == "MT-2")
             {
-                _applicationProgram.MaskVersion = "MV-2705";
+                _applicationProgram.MaskVersion = "MV-27B0";
                 _hardware.IsIPEnabled = false;
                 _hardware.BusCurrent = null;
             }


### PR DESCRIPTION
I have successfully created a knxprod file for medium RF.

However, during testing of the device RF implementation I have found out that I have to use mask version 27B0 to successfully program a RF device.

Kind of clear now as you have implemented SystemB profile and not System7. 
The real KNX RF device that I had used for comparing behaviour is a MDT KNX-RF Shutter Actuator and it used mask version 2705 implementing System7 only. Using this System7 mask resulted in a different ETS behaviour towards my custom RF device and programming did not succeed.

Using SystemB mask 27B0 now everything seems to work.

I will create a pull request for the stack update some time later after cleaning up things.