### PR TITLE
Fix RefIds in all files

### DIFF
--- a/CreateKnxProd.csproj
+++ b/CreateKnxProd.csproj
@@ -101,6 +101,10 @@
     <Compile Include="Model\Parameter_t.cs" />
     <Compile Include="Model\Xml.Project.cs" />
     <Compile Include="RelayCommand.cs" />
+    <Compile Include="Signing\ApplicationProgramHasher.cs" />
+    <Compile Include="Signing\CatalogIdPatcher.cs" />
+    <Compile Include="Signing\HardwareSigner.cs" />
+    <Compile Include="Signing\XmlSigning.cs" />
     <Page Include="MainWindow.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>

--- a/Signing/ApplicationProgramHasher.cs
+++ b/Signing/ApplicationProgramHasher.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.IO;
+
+namespace CreateKnxProd.Signing
+{
+    class ApplicationProgramHasher
+    {
+        public ApplicationProgramHasher(
+                   FileInfo applProgFile,
+                   IDictionary<string, string> mapBaggageIdToFileIntegrity,
+                   bool patchIds = true)
+        {
+            Assembly asm = Assembly.LoadFrom("C:\\Program Files (x86)\\ETS5\\Knx.Ets.XmlSigning.dll");
+            _instance = Activator.CreateInstance(asm.GetType("Knx.Ets.XmlSigning.ApplicationProgramHasher"), applProgFile, mapBaggageIdToFileIntegrity, patchIds);
+            _type = asm.GetType("Knx.Ets.XmlSigning.ApplicationProgramHasher");
+        }
+
+        public void HashFile()
+        {
+            _type.GetMethod("HashFile", BindingFlags.Instance | BindingFlags.Public).Invoke(_instance, null);
+        }
+
+        public string OldApplProgId
+        {
+            get
+            {
+                return _type.GetProperty("OldApplProgId", BindingFlags.Public | BindingFlags.Instance).GetValue(_instance).ToString();
+            }
+        }
+
+        public string NewApplProgId
+        {
+            get
+            {
+                return _type.GetProperty("NewApplProgId", BindingFlags.Public | BindingFlags.Instance).GetValue(_instance).ToString();
+            }
+        }
+
+        public string GeneratedHashString
+        {
+            get
+            {
+                return _type.GetProperty("GeneratedHashString", BindingFlags.Public | BindingFlags.Instance).GetValue(_instance).ToString();
+            }
+        }
+
+        private readonly object _instance;
+        private readonly Type _type;
+    }
+}

--- a/Signing/CatalogIdPatcher.cs
+++ b/Signing/CatalogIdPatcher.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.IO;
+
+namespace CreateKnxProd.Signing
+{
+    class CatalogIdPatcher
+    {
+        public CatalogIdPatcher(
+            FileInfo catalogFile,
+            IDictionary<string, string> hardware2ProgramIdMapping)
+        {
+            Assembly asm = Assembly.LoadFrom("C:\\Program Files (x86)\\ETS5\\Knx.Ets.XmlSigning.dll");
+            _instance = Activator.CreateInstance(asm.GetType("Knx.Ets.XmlSigning.CatalogIdPatcher"), catalogFile, hardware2ProgramIdMapping);
+            _type = asm.GetType("Knx.Ets.XmlSigning.CatalogIdPatcher");
+        }
+
+        public void Patch()
+        {
+            _type.GetMethod("Patch", BindingFlags.Instance | BindingFlags.Public).Invoke(_instance, null);
+        }
+
+        private readonly object _instance;
+        private readonly Type _type;
+    }
+}

--- a/Signing/HardwareSigner.cs
+++ b/Signing/HardwareSigner.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.IO;
+
+namespace CreateKnxProd.Signing
+{
+    class HardwareSigner
+    {
+        public HardwareSigner(
+             FileInfo hardwareFile,
+             IDictionary<string, string> applProgIdMappings,
+             IDictionary<string, string> applProgHashes,
+             bool patchIds)
+        {
+            Assembly asm1 = Assembly.LoadFrom("C:\\Program Files (x86)\\ETS5\\Knx.Ets.XmlSigning.dll");
+            Assembly asm2 = Assembly.LoadFrom("C:\\Program Files (x86)\\ETS5\\Knx.Ets.Xml.ObjectModel.dll");
+
+            Type RegistrationKeyEnum = asm2.GetType("Knx.Ets.Xml.ObjectModel.RegistrationKey");
+            object registrationKey = Enum.Parse(RegistrationKeyEnum, "knxconv");
+
+            // registrationKey= Knx.Ets.Xml.ObjectModel.RegistrationKey.knxconv (is an enum)
+            _instance = Activator.CreateInstance(asm1.GetType("Knx.Ets.XmlSigning.HardwareSigner"), hardwareFile, applProgIdMappings, applProgHashes, patchIds, registrationKey);
+            _type = asm1.GetType("Knx.Ets.XmlSigning.HardwareSigner");
+        }
+
+        public void SignFile()
+        {
+            _type.GetMethod("SignFile", BindingFlags.Instance | BindingFlags.Public).Invoke(_instance, null);
+        }
+
+        private readonly object _instance;
+        private readonly Type _type;
+
+        public IDictionary<string, string> OldNewIdMappings
+        {
+            get
+            {
+                return (IDictionary<string, string>)_type.GetProperty("OldNewIdMappings", BindingFlags.Public | BindingFlags.Instance).GetValue(_instance);
+            }
+        }
+    }
+}

--- a/Signing/XmlSigning.cs
+++ b/Signing/XmlSigning.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Reflection;
+using System.IO;
+
+namespace CreateKnxProd.Signing
+{
+    class XmlSigning
+    {
+        public static void SignDirectory(
+            string path,
+            bool useCasingOfBaggagesXml = false,
+            string[] excludeFileEndings = null)
+        {
+            Assembly asm = Assembly.LoadFrom("C:\\Program Files (x86)\\ETS5\\Knx.Ets.XmlSigning.dll");
+
+            Type ds = asm.GetType("Knx.Ets.XmlSigning.XmlSigning");
+
+            ds.GetMethod("SignDirectory", BindingFlags.Static | BindingFlags.NonPublic).Invoke(null, new object[] { path, useCasingOfBaggagesXml, excludeFileEndings });
+        }
+    }
+}


### PR DESCRIPTION
Fix RefIds in all XML file by enabling automatic patching.
Catalog.xml is patched by a dedicated class for this.

UPDATE:
Also moved each class in its own file and created a subdir for the namespace.