### PR TITLE
fix export when output file already exists

### DIFF
--- a/MainWindowViewModel.cs
+++ b/MainWindowViewModel.cs
@@ -702,6 +702,10 @@ namespace CreateKnxProd
 
                 // Signing directory
                 XmlSigning.SignDirectory(Path.Combine(tempDirectory, mfid));
+                
+                //Check if ZIP already exists and delete
+                if (File.Exists(outputFile))
+                    File.Delete(outputFile);
 
                 // Create ZIP file (aka knxprod) archive
                 ZipFile.CreateFromDirectory(tempDirectory, outputFile);


### PR DESCRIPTION
When the knxprod already exists, ZipFile.CreateFromDirectory throws an IO exception.
This PR checks if the file already exists and deletes the existing one.